### PR TITLE
automatically detect if run on robot

### DIFF
--- a/opentronsfastapi/__init__.py
+++ b/opentronsfastapi/__init__.py
@@ -8,6 +8,7 @@ import inspect
 import hashlib
 import opentrons.execute as oe
 import opentrons.simulate as os
+import opentrons.config
 from typing import List
 from functools import wraps
 
@@ -17,7 +18,10 @@ default_app = FastAPI()
 default_routes = APIRouter()
 
 global opentrons_env
-opentrons_env = os
+if opentrons.config.IS_ROBOT:
+    opentrons_env = oe
+else:
+    opentrons_env = os
 
 
 # Setup sqlite3 lock


### PR DESCRIPTION
OT provides a config attribute that says whether the runtime is happening on a robot - used that inform whether opentrons.execute or opentrons.simulate should be used.